### PR TITLE
adjust checkConfig to allow null values

### DIFF
--- a/index.js
+++ b/index.js
@@ -9,7 +9,8 @@ const magenta = "#FF2D55";
 const cyan = "#5AC8FA";
 const white = "#FFFFFF";
 const defaultConfig = {
-  fontFamily: '"SF Mono", "Monaco", "Inconsolata", "Fira Mono", "Droid Sans Mono", "Source Code Pro", monospace',
+  fontFamily:
+    '"SF Mono", "Monaco", "Inconsolata", "Fira Mono", "Droid Sans Mono", "Source Code Pro", monospace',
   fontSize: 12,
   foregroundColor,
   backgroundColor,
@@ -32,57 +33,68 @@ const defaultConfig = {
     lightBlue: blue,
     lightMagenta: magenta,
     lightCyan: cyan,
-    lightWhite: foregroundColor,
+    lightWhite: foregroundColor
   },
   vibrancy: "ultra-dark"
 };
 
 // Check if Verminal configuration exists in ~/.hyper.js. If not, fall back to default configuration.
-const checkConfig = (config, setting) => config.hasOwnProperty("verminal") && config.verminal[setting] !== undefined ? 
-config.verminal[setting]  : defaultConfig[setting]
+const checkConfig = (config, setting) =>
+  config.hasOwnProperty("verminal") && config.verminal[setting] !== undefined
+    ? config.verminal[setting]
+    : defaultConfig[setting];
 
-const checkConfigColor = (config, colorName) => (config.hasOwnProperty("verminal") && config.verminal.colors && config.verminal.colors[colorName]) || defaultConfig.colors[colorName]
+const checkConfigColor = (config, colorName) =>
+  (config.hasOwnProperty("verminal") &&
+    config.verminal.colors &&
+    config.verminal.colors[colorName]) ||
+  defaultConfig.colors[colorName];
 
 // Setup configs
 exports.decorateConfig = config => {
   // Setup vibrancy
-  exports.onWindow = browserWindow => browserWindow.setVibrancy(checkConfig(config, "vibrancy"))
+  exports.onWindow = browserWindow =>
+    browserWindow.setVibrancy(checkConfig(config, "vibrancy"));
 
   return Object.assign({}, config, {
-        fontFamily: checkConfig(config, "fontFamily"),
-        fontSize: checkConfig(config, "fontSize"),
-        fontWeight: checkConfig(config, "fontWeight"),
-        fontWeightBold: checkConfig(config, "fontWeightBold"),
-        backgroundColor: checkConfig(config, "backgroundColor"),
-        foregroundColor: checkConfig(config, "foregroundColor"),
-        borderColor: checkConfig(config, "borderColor"),
-        cursorColor: checkConfig(config, "cursorColor"),
-        minimal: checkConfig(config, "minimal"),
-        colors: {
-          black: checkConfigColor(config, "black"),
-          red: checkConfigColor(config, "red"),
-          green: checkConfigColor(config, "green"),
-          yellow: checkConfigColor(config, "yellow"),
-          blue: checkConfigColor(config, "blue"),
-          magenta: checkConfigColor(config, "magenta"),
-          cyan: checkConfigColor(config, "cyan"),
-          white: checkConfigColor(config, "white"),
-          lightBlack: checkConfigColor(config, "lightBlack"),
-          lightRed: checkConfigColor(config, "lightRed"),
-          lightGreen: checkConfigColor(config, "lightGreen"),
-          lightYellow: checkConfigColor(config, "lightYellow"),
-          lightBlue: checkConfigColor(config, "lightBlue"),
-          lightMagenta: checkConfigColor(config, "lightMagenta"),
-          lightCyan: checkConfigColor(config, "lightCyan"),
-          lightWhite: checkConfigColor(config, "lightWhite")
-        },
-        css: `
+    fontFamily: checkConfig(config, "fontFamily"),
+    fontSize: checkConfig(config, "fontSize"),
+    fontWeight: checkConfig(config, "fontWeight"),
+    fontWeightBold: checkConfig(config, "fontWeightBold"),
+    backgroundColor: checkConfig(config, "backgroundColor"),
+    foregroundColor: checkConfig(config, "foregroundColor"),
+    borderColor: checkConfig(config, "borderColor"),
+    cursorColor: checkConfig(config, "cursorColor"),
+    minimal: checkConfig(config, "minimal"),
+    colors: {
+      black: checkConfigColor(config, "black"),
+      red: checkConfigColor(config, "red"),
+      green: checkConfigColor(config, "green"),
+      yellow: checkConfigColor(config, "yellow"),
+      blue: checkConfigColor(config, "blue"),
+      magenta: checkConfigColor(config, "magenta"),
+      cyan: checkConfigColor(config, "cyan"),
+      white: checkConfigColor(config, "white"),
+      lightBlack: checkConfigColor(config, "lightBlack"),
+      lightRed: checkConfigColor(config, "lightRed"),
+      lightGreen: checkConfigColor(config, "lightGreen"),
+      lightYellow: checkConfigColor(config, "lightYellow"),
+      lightBlue: checkConfigColor(config, "lightBlue"),
+      lightMagenta: checkConfigColor(config, "lightMagenta"),
+      lightCyan: checkConfigColor(config, "lightCyan"),
+      lightWhite: checkConfigColor(config, "lightWhite")
+    },
+    css: `
     .hyper_main {
       border: none !important;
     }
 
     .header_header {
-      background-color: ${config && config.verminal && config.verminal.minimal ? 'transparent' : overlap} !important;
+      background-color: ${
+        config && config.verminal && config.verminal.minimal
+          ? "transparent"
+          : overlap
+      } !important;
     }
 
     .tabs_borderShim {
@@ -141,6 +153,6 @@ exports.decorateConfig = config => {
     }
 
     ${config.css}
-  `,
-  })
+  `
+  });
 };

--- a/index.js
+++ b/index.js
@@ -38,7 +38,9 @@ const defaultConfig = {
 };
 
 // Check if Verminal configuration exists in ~/.hyper.js. If not, fall back to default configuration.
-const checkConfig = (config, setting) => (config.hasOwnProperty("verminal") && config.verminal[setting]) || defaultConfig[setting]
+const checkConfig = (config, setting) => config.hasOwnProperty("verminal") && config.verminal[setting] !== undefined ? 
+config.verminal[setting]  : defaultConfig[setting]
+
 const checkConfigColor = (config, colorName) => (config.hasOwnProperty("verminal") && config.verminal.colors && config.verminal.colors[colorName]) || defaultConfig.colors[colorName]
 
 // Setup configs


### PR DESCRIPTION
while #30 makes the vibrancy value configurable, the checkConfig function treats the value null as undefined. This PR changes the function to explicitly check for undefined, so `vibrancy: null` actually disables the vibrancy.